### PR TITLE
Fix to get it Copy URL to Clipboard working on El Capitan

### DIFF
--- a/Copy URL to Clipboard/Copy URL to Clipboard/Copy URL to Clipboard-Info.plist
+++ b/Copy URL to Clipboard/Copy URL to Clipboard/Copy URL to Clipboard-Info.plist
@@ -36,8 +36,15 @@
 	<true/>
 	<key>CFBundleURLTypes</key>
 	<array>
-        <string>http</string>
-        <string>https</string>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>Web site URL</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>http</string>
+				<string>https</string>
+			</array>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
As mentioned [here](http://apple.stackexchange.com/questions/218051/copy-url-to-clipboard-app-is-not-available-as-a-http-browser-in-el-capitan) the Copy URL to Clipboard application isn't recognised by El Capitan as an HTTP or HTTPS handler. This small change fixes this.